### PR TITLE
Cli: use process.cwd() as savePath + show the save file path in the end

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -29,6 +29,7 @@ parser.addArgument(['-n', '--name'], {
 export default {
     download () {
         const args = parser.parseArgs();
-        return downloadUtils.download(args.url, __dirname, args.name || 'extension');
+        const savePath = process.cwd();
+        return downloadUtils.download(args.url, savePath, args.name || 'extension');
     }
 };

--- a/src/cli.js
+++ b/src/cli.js
@@ -30,6 +30,10 @@ export default {
     download () {
         const args = parser.parseArgs();
         const savePath = process.cwd();
-        return downloadUtils.download(args.url, savePath, args.name || 'extension');
+
+        return downloadUtils
+          .download(args.url, savePath, args.name || 'extension')
+          .then(filePath => console.log(`Saved in ${filePath}`))
+          .catch(err => conole.log(err))
     }
 };


### PR DESCRIPTION
Usually we expect a command line tool to download in the current working directory (like `wget`)