### PR TITLE
Use a more modern URL for fetching the CRX

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ import _ from 'lodash';
 import got from 'got';
 import URI from 'urijs';
 
-const URL_PATTERN = 'https://clients2.google.com/service/update2/crx?response=redirect&prodversion=38.0&x=id%3D[EXTENSION_ID]%26installsource%3Dondemand%26uc';
+const URL_PATTERN = 'https://update.googleapis.com/service/update2/crx?response=redirect&acceptformat=crx3&prodversion=38.0&testsource=download-crx&x=id%3D[EXTENSION_ID]%26installsource%3Dondemand%26uc';
 const USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.84 Safari/537.36';
 
 const headers = {


### PR DESCRIPTION
1 • update.googleapis.com is newer and has better availability than clients2.google.com.
2 • acceptformat=crx3 indicates the client requires a CRX₃ response. CRX₂ is the default for backward compatibility, but will not load in Chrome 73+. (See https://crbug.com/941356)
3 • testsource=download-crx identifies the client to the server as not a production Chrome and asks the server to treat its traffic as not-ranking-affecting. (For posterity: from Google's perspective, testsource is sufficient but not necessary to identify a client as not ranking-affecting - i.e. the web store reserves the right to discount various traffic as spammy / malicious - but we ask that friendly clients use it to aid in debuggability and avoid being mistaken for attempts to manipulate rankings.)

To test: confirm the script still works with your favorite extension. Confirm the download is a CRX₃ by inspecting the 5th octet of the file: CRX₃ has \03, CRX₂ has \02.